### PR TITLE
fixed wrong config path in rhel init script

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.getchef.com"
 
 metadata
 

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -8,7 +8,8 @@ DEPENDENCIES
 GRAPH
   apt (2.4.0)
   build-essential (2.0.4)
-  monit (1.5.4)
+  monit (1.5.6)
+    apt (>= 0.0.0)
     build-essential (>= 0.0.0)
   yum (3.2.2)
   yum-epel (0.3.6)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,14 +4,14 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Configures monit"
 long_description  "Please refer to README.md"
-version           "1.5.5"
+version           "1.5.6"
 
 recipe "monit", "Sets up the service definition and default checks."
 recipe "monit::install_source", "Compiles and installs monit from source."
 recipe "monit::install_binary", "Installs monit from a binary package."
 
 depends "build-essential"
-suggests "apt"
+depends "apt"
 suggests "yum-epel"
 
 supports "ubuntu"

--- a/templates/default/rhel/monit.init.erb
+++ b/templates/default/rhel/monit.init.erb
@@ -16,7 +16,7 @@
 . /etc/init.d/functions
 
 ### Default variables
-CONFIG="/etc/monit.conf"
+CONFIG="<%= @config %>"
 pidfile="/var/run/monit.pid"
 prog="monit"
 


### PR DESCRIPTION
Hi there, the config attribute was missing in the rhel init script template.
